### PR TITLE
Make window fullscreen so that devices with larger resolutions show properly, and so that themes generate for those resolutions properly

### DIFF
--- a/src/conf.lua
+++ b/src/conf.lua
@@ -6,6 +6,7 @@ function love.conf(t)
 	t.window.width = 640
 	t.window.height = 480
 	t.window.resizable = true
+	t.window.fullscreen = true
 	t.window.title = "Aesthetic"
 	t.window.borderless = true -- Useful for screenshots
 end


### PR DESCRIPTION
Tested this on my rgcubexx, beforehand the window was what appeared to be 4:3 and the fonts were fuzzy; themes generated in this way also were in 4:3 with fuzzy fonts. Adding this made the app's fonts look sharp, and the theme uses the full screen resolution too!

some more tweaks might be needed, like the width of items still isn't full width (settings with changeable values don't fully extend the values to the right, and the selection bar isn't full width as well) but the generated theme still looks much better than before.

![image](https://github.com/user-attachments/assets/ede5f5ce-2393-4241-b6e7-6c385c086548)